### PR TITLE
Fix wy script for git bash and spaces in paths

### DIFF
--- a/bin/wy
+++ b/bin/wy
@@ -38,17 +38,18 @@ LIBDIR=$DIR/lib
 #LIBS="wycc wyc wyjc wytp wyjs jasm"
 
 # check for running under cywin
-cygwin=false
+windows=false
 case "`uname`" in
-  CYGWIN*) cygwin=true ;;
+  CYGWIN*) windows=true ;;
+  MINGW*) windows=true ;;
 esac
 
 ######################
 # CONSTRUCT CLASSPATH
 ######################
 
-if $cygwin; then
-    # under cygwin the classpath separator must be ";"
+if $windows; then
+    # under windows the classpath separator must be ";"
     LIBDIR=`cygpath -m "$LIBDIR"`
     PATHSEP=";"
 else
@@ -56,13 +57,14 @@ else
     PATHSEP=":"
 fi
 
-LIBS=`ls $LIBDIR/*.jar`
+LIBS=`ls "$LIBDIR"/*.jar`
 WHILEY_CLASSPATH=$CLASSPATH
 
 # as there may more than one version of the jar files
 # it is important to first use the * expansion, and then
 # use the last one via the "##* " expansion.
 
+IFS=$'\n'
 for JAR in $LIBS
 do
     case "$JAR" in


### PR DESCRIPTION
These are the changes I had to make in order to get the `wy` script running under git bash on windows (which uses MinGW).

* Check for both MINGW and CYGWIN for windows
* Handle spaces in the path to the WDK (`IFS=$'\n'` sets which character the for loop splits on)