### PR TITLE
Add README.txt to distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@
 *.war
 *.ear
 
+# Temp Files
+tmp/
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,52 @@
+Whiley Development Kit (WDK)
+============================
+
+The Whiley Development Kit provides a command-line interface for
+compiling and running Whiley programs. See [whiley.org](http://whiley.org) for
+more information on the language.
+
+Install
+--------------------
+
+To install the Whiley Development Kit, first place the WDK containing this
+readme into an appropriate directory. You then need to make sure that the `PATH`
+environment variable points to the `bin/` directory inside where you placed the
+WDK, where several scripts are provided for running Whiley. Then set the
+`WHILEYHOME` environment variable to the directory of the WDK.
+
+Run
+--------------------
+
+With the `PATH` setup correctly, you should be able to run the `wy` tool
+to compile Whiley programs as follows:
+
+    % cd examples
+    % wy compile hello-world.whiley
+
+At this point, you can run the program using the `wy` tool:
+
+    % wy run hello-world
+    Hello World
+
+Command-Line Options
+--------------------
+
+To see the available command-line options, run `wy help`:
+
+usage: wy [--verbose] command [<options>] [<args>]
+
+Commands:
+  help          Display help information
+  compile       Compile one or more Whiley source files
+  decompile     Decompile one or more binary WyIL files
+  run           Execute a given method from a WyIL
+  verify        Compile and verify one or more WyAL files
+  jvmcompile    Compile Whiley source files to JVM class files
+  javacompile   Compile Whiley source files to Java source files
+  jvmrun        Execute a given classfile (requires main method)
+  jscompile     Compile Whiley source files to JavaScript source files [EXPERIMENTAL]
+
+Run `wy help COMMAND` for more information on a command
+
+You can then find out more information about each command as
+indicated.

--- a/build.xml
+++ b/build.xml
@@ -21,6 +21,7 @@
     <copy todir="${RELEASE_DIR}">
       <fileset dir=".">
 	<include name="config.wyml"/>
+	<include name="README.txt"/>
       </fileset>      
     </copy>
     <echo message="Copying dependencies..."/>


### PR DESCRIPTION
This adds a README.txt to the root of the `.tar.gz` file of the distribution. The readme file is adapted from the current README.md file. I've made the formatting more like what one would expect for a straight text file and modified the wording to reflect the fact that the file is inside the distro rather than the repo (i.e. assume you have already gotten and unpacked the file).

Also, added `tmp/` to git ignore because it was populated when running `ant` on my machine.

Fixes #3 

P.S. you might want to put some explanation at the bottom of README.md for running `ant`. It took me a while to figure out which build tool you were using.